### PR TITLE
5 feature request trailer mpa rating

### DIFF
--- a/Jellyfin.Plugin.CinemaMode/Channels/PreRollsChannel.cs
+++ b/Jellyfin.Plugin.CinemaMode/Channels/PreRollsChannel.cs
@@ -134,7 +134,7 @@ public class PreRollsChannel : IChannel, IDisableMediaSourceDisplay, ISupportsMe
                 // Create media source
                 List<MediaSourceInfo> mediaSources = new List<MediaSourceInfo>();
                 mediaSources.Add(
-                    new MediaSourceInfo 
+                    new MediaSourceInfo
                     {
                         Path = preRoll,
                         Name = System.IO.Path.GetFileNameWithoutExtension(preRoll),
@@ -226,7 +226,7 @@ public class PreRollsChannel : IChannel, IDisableMediaSourceDisplay, ISupportsMe
         {
             // Get this channel
             var q = Plugin.LibraryManager.GetItemList(
-                new InternalItemsQuery 
+                new InternalItemsQuery
                 {
                     Name = Name,
                     IncludeItemTypes = new BaseItemKind[] { BaseItemKind.Channel }
@@ -266,7 +266,9 @@ public class PreRollsChannel : IChannel, IDisableMediaSourceDisplay, ISupportsMe
                 }
                 _logger.LogInformation($"Finished refreshing channel: {thisChannel.Name}");
 
-            } else {
+            }
+            else
+            {
                 _logger.LogInformation("Failed to find channel when attempting to refresh");
             }
 
@@ -285,12 +287,13 @@ public class PreRollsChannel : IChannel, IDisableMediaSourceDisplay, ISupportsMe
         yield return new TaskTriggerInfo { Type = TaskTriggerInfo.TriggerStartup };
 
         // Every so often
-        yield return new TaskTriggerInfo {
+        yield return new TaskTriggerInfo
+        {
             Type = TaskTriggerInfo.TriggerDaily,
             TimeOfDayTicks = TimeSpan.FromHours(2).Ticks,
             MaxRuntimeTicks = TimeSpan.FromHours(4).Ticks
         };
-        
+
     }
 
 }

--- a/Jellyfin.Plugin.CinemaMode/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.CinemaMode/Configuration/PluginConfiguration.cs
@@ -14,7 +14,7 @@ namespace Jellyfin.Plugin.CinemaMode.Configuration
         public bool EnableTrailerPreroll { get; set; }
 
         public bool EnableFeaturePreroll { get; set; }
-        
+
         public bool EnforceRatingLimit { get; set; }
 
         public string TrailerPreRollsChannelName { get; } = "Trailer Pre-Rolls";

--- a/Jellyfin.Plugin.CinemaMode/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.CinemaMode/Configuration/PluginConfiguration.cs
@@ -14,6 +14,8 @@ namespace Jellyfin.Plugin.CinemaMode.Configuration
         public bool EnableTrailerPreroll { get; set; }
 
         public bool EnableFeaturePreroll { get; set; }
+        
+        public bool EnforceRatingLimit { get; set; }
 
         public string TrailerPreRollsChannelName { get; } = "Trailer Pre-Rolls";
 
@@ -26,6 +28,7 @@ namespace Jellyfin.Plugin.CinemaMode.Configuration
             NumberOfTrailers = 2;
             EnableTrailerPreroll = false;
             EnableFeaturePreroll = false;
+            EnforceRatingLimit = true;
         }
     }
 }

--- a/Jellyfin.Plugin.CinemaMode/Configuration/config.html
+++ b/Jellyfin.Plugin.CinemaMode/Configuration/config.html
@@ -14,33 +14,25 @@
                     </div>
                     <div class="verticalSection">
                         <p>
-                            This plugin allows users to enable Jellyfin's Cinema Mode functionality with local trailers and pre-rolls. 
-                            The system admin can configure a set number of trailers to play before a movie. In addition, pre-roll videos 
-                            can be played before and after the block of trailers. All of this can be disabled at the user level by turning 
-                            off Cinema Mode in the users Playback settings. For more information, access the user guide via the above help
-                            button. Pro tip: Skip any pre-roll or trailer by pressing the next button in the player.
+                            This plugin allows users to enable Jellyfin's Cinema Mode functionality with Trailer Pre-Rolls, 
+                            Trailers, and Feature Pre-Rolls. Each of these can be configured/turned off in the sections 
+                            below. All of this can be disabled at the user level by turning off Cinema Mode in the users 
+                            Playback settings. For more information, access the user guide via the above help button. Pro 
+                            tip: Skip any pre-roll or trailer by pressing the next button in the player.
                         </p>
                         <br/>
                     </div>
+                    
+                    <!-- Trailer Pre Rolls -->
+                    <h2 class="sectionTitle">Trailer Pre-Rolls</h2>
+                    <p>These play before the block of trailers. Think "Now playing on Jellyfin..."</p>
                     <div class="inputContainer">
                         <label class="inputLabel inputLabelUnfocused" for="trailer-prerolls">Trailer Pre-Rolls Folder</label>
                         <input type="string" id="trailer-prerolls" name="trailer-prerolls" is="emby-input"/>
                         <div class="fieldDescription">
-                            Specify location of trailer pre-roll videos. (Should contain only videso, no subdirectories) 
-                        </div>
-                    </div>
-                    <div class="inputContainer">
-                        <label class="inputLabel inputLabelUnfocused" for="feature-prerolls">Feature Pre-Rolls Folder</label>
-                        <input type="string" id="feature-prerolls" name="feature-prerolls" is="emby-input"/>
-                        <div class="fieldDescription">
-                            Specify location of feature pre-roll videos. (Should contain only videso, no subdirectories) 
-                        </div>
-                    </div>
-                    <div class="inputContainer">
-                        <label class="inputLabel inputLabelUnfocused" for="number-trailers">Number of Trailers</label>
-                        <input type="number" id="number-trailers" name="number-trailers" is="emby-input"/>
-                        <div class="fieldDescription">
-                            Specify the number of trailers to play.
+                            Location of trailer pre-roll videos (should contain only videos, no subdirectories). Content in this folder 
+                            is scanned and updated automatically in the database once every 24 hours. To manually trigger a scan, you must open
+                            the Trailer Pre-Rolls channel. Do this when adding/removing content.
                         </div>
                     </div>
                     <div class="checkboxContainer checkboxContainer-withDescription">
@@ -50,6 +42,45 @@
                         </label>
                         <div class="fieldDescription checkboxFieldDescription">
                             One random trailer pre-roll video will play before the trailers start.
+                        </div>
+                    </div>
+                    <br/>
+
+                    <!-- Trailers -->
+                    <h2 class="sectionTitle">Trailers</h2>
+                    <p>Trailers you have stored with your movies.</p>
+                    <div class="inputContainer">
+                        <label class="inputLabel inputLabelUnfocused" for="number-trailers">Number of Trailers</label>
+                        <input type="number" id="number-trailers" name="number-trailers" is="emby-input"/>
+                        <div class="fieldDescription">
+                            The number of trailers to play. Setting at 0 will turn this section off. 
+                        </div>
+                    </div>
+                    <div class="checkboxContainer checkboxContainer-withDescription">
+                        <label>
+                            <input is="emby-checkbox" type="checkbox" id="enforce-rating-limit" name="enforce-rating-limit" />
+                            <span>Enforce Rating Limit</span>
+                        </label>
+                        <div class="fieldDescription checkboxFieldDescription">
+                            Ensures the rating of the trailer content does not exceed that of the feature (i.e. trailers for an "R" 
+                            rated movie will not be shown before a "PG-13" movie). This setting will cause any unrated content to 
+                            have no trailers played prior and not be shown as a trailer. In this case "unrated" refers to content 
+                            where the "Parental Rating" field is blank. It does not refer to content with an "NR" or "Not Rated" rating.
+                            Jellyfin considers content with a rating of "NR" as exceeding an "R" rating.
+                        </div>
+                    </div>
+                    <br/>
+                    
+                    <!-- Feature Pre Rolls -->
+                    <h2 class="sectionTitle">Feature Pre-Rolls</h2>
+                    <p>These play after the block of trailers. Think "Now your feature presentation..."</p>
+                    <div class="inputContainer">
+                        <label class="inputLabel inputLabelUnfocused" for="feature-prerolls">Feature Pre-Rolls Folder</label>
+                        <input type="string" id="feature-prerolls" name="feature-prerolls" is="emby-input"/>
+                        <div class="fieldDescription">
+                            Location of feature pre-roll videos (Should contain only videos, no subdirectories). Content in this folder 
+                            is scanned and updated automatically in the database once every 24 hours. To manually trigger a scan, you must open
+                            the Feature Pre-Rolls channel. Do this when adding/removing content. 
                         </div>
                     </div>
                     <div class="checkboxContainer checkboxContainer-withDescription">
@@ -78,6 +109,7 @@
                     $('#number-trailers', page).val(config.NumberOfTrailers);
                     document.getElementById('enable-trailer-preroll').checked = config.EnableTrailerPreroll;
                     document.getElementById('enable-feature-preroll').checked = config.EnableFeaturePreroll;
+                    document.getElementById('enforce-rating-limit').checked = config.EnforceRatingLimit;
                     Dashboard.hideLoadingMsg();
                 });
             });
@@ -95,7 +127,7 @@
                     config.NumberOfTrailers = parseInt(NumberOfTrailers);
                     config.EnableTrailerPreroll = document.getElementById('enable-trailer-preroll').checked;
                     config.EnableFeaturePreroll = document.getElementById('enable-feature-preroll').checked;
-
+                    config.EnforceRatingLimit = document.getElementById('enforce-rating-limit').checked;
                     ApiClient.updatePluginConfiguration(pluginId, config).then(Dashboard.processPluginConfigurationUpdateResult);
                 });
 

--- a/Jellyfin.Plugin.CinemaMode/IntroManager.cs
+++ b/Jellyfin.Plugin.CinemaMode/IntroManager.cs
@@ -11,39 +11,86 @@ using Jellyfin.Data.Enums;
 
 namespace Jellyfin.Plugin.CinemaMode
 {
+    
+    class TrailerSelector
+    {
+        private List<Movie> Trailers { get; set; } = new List<Movie>(){ };
+        private int Returned { get; set; } = 0;
+        private Random RNG { get; }
+        private Jellyfin.Plugin.CinemaMode.Configuration.PluginConfiguration Config { get; }
+        private BaseItem Feature { get; }
+        private User User { get; }
+
+        private void QueryTrailers(bool IsPlayed)
+        {
+            InternalItemsQuery q = new InternalItemsQuery(this.User);
+            q.HasTrailer = true;
+            q.IncludeItemTypes = new BaseItemKind[] { BaseItemKind.Movie };
+            q.IsPlayed = IsPlayed;
+            q.ExcludeItemIds = new Guid[] { this.Feature.Id };
+            if (this.Config.EnforceRatingLimit)
+            {
+                q.HasOfficialRating = true;
+                q.MaxParentalRating = this.Feature.InheritedParentalRatingValue;
+            }
+            
+            List<Movie> movies = Plugin.LibraryManager.GetItemList(q).OfType<Movie>().Where(x => x.LocalTrailers.Count > 0).ToList();
+
+            if (movies is not null)
+            {
+                this.Trailers = movies;
+            }
+        }
+
+        public TrailerSelector(BaseItem Feature, User User, Jellyfin.Plugin.CinemaMode.Configuration.PluginConfiguration Config)
+        {
+            this.RNG = new Random();
+            this.Config = Config;
+            this.Feature = Feature;
+            this.User = User;
+        }
+
+        public IntroInfo PickAndPop()
+        {
+            int idx = this.RNG.Next(this.Trailers.Count);
+            Movie movie = this.Trailers.ElementAt(idx);
+            this.Trailers.RemoveAt(idx);
+
+            int trailerID = this.RNG.Next(movie.LocalTrailers.Count);
+            BaseItem item = movie.LocalTrailers.ElementAt(trailerID);
+            return new IntroInfo { ItemId = item.Id, Path = item.Path };
+        }
+        
+        public IEnumerable<IntroInfo> GetTrailers()
+        {
+            // Unplayed
+            this.QueryTrailers(false);
+            while (this.Trailers.Count != 0 && this.Returned < this.Config.NumberOfTrailers)
+            {
+                yield return this.PickAndPop();
+                this.Returned++;                 
+            }
+
+            // Break if we have reached count
+            if (this.Returned == this.Config.NumberOfTrailers)
+            {
+                yield break;
+            }
+
+            // Played
+            this.QueryTrailers(true);
+            while (this.Trailers.Count != 0 && this.Returned < this.Config.NumberOfTrailers)
+            {
+                yield return this.PickAndPop();
+                this.Returned++;
+            }
+            
+        }
+    }
+
     public class IntroManager
     {
         private readonly Random _random = new Random();
-
-        public List<Guid> exclusion_list = new List<Guid>();
-
-        public BaseItem? GetRandomMovieTrailer(bool isplayed, User user)
-        {
-            // Query movies
-            InternalItemsQuery q = new InternalItemsQuery(user);
-            q.HasTrailer = true;
-            q.IncludeItemTypes = new BaseItemKind[] { BaseItemKind.Movie };
-            q.ExcludeItemIds = exclusion_list.ToArray();
-            q.IsPlayed = isplayed;
-            IReadOnlyCollection<BaseItem> movies = Plugin.LibraryManager.GetItemList(q);
-
-            // Check for no results
-            if (movies.Count == 0)
-            {
-                return null;
-            }
-
-            // Get trailers and id to exculsion list
-            Movie? movie = movies.ElementAt(_random.Next(movies.Count)) as Movie;
-            if (movie is null)
-            {
-                return null;
-            }
-            
-            exclusion_list.Add(movie.Id);
-            IReadOnlyList<BaseItem> localTrailers = movie.LocalTrailers;
-            return localTrailers.ElementAt(_random.Next(localTrailers.Count));
-        }
 
         public BaseItem? GetRandomPreRoll(string preRollChannelPath, string preRollChannelName)
         {
@@ -106,36 +153,14 @@ namespace Jellyfin.Plugin.CinemaMode
                 }
             }
 
-            // Empty list
-            int introInfoCount = 0;
-
-            // Exclude Base Item
-            exclusion_list.Add(item.Id);
-
-            // Try to get unplayed trailers
-            for (int i = 0; i < Plugin.Instance.Configuration.NumberOfTrailers; i++)
+            // Return Trailers
+            if (Plugin.Instance.Configuration.NumberOfTrailers > 0)
             {
-                BaseItem? b = GetRandomMovieTrailer(false, user);
-                if (b == null)
-                {   
-                    // Move on to played movies
-                    break;
-                }
-                yield return new IntroInfo { ItemId = b.Id, Path = b.Path };
-                introInfoCount ++;
-            }
-
-            // Fill the gaps
-            int empty_spots = Plugin.Instance.Configuration.NumberOfTrailers - introInfoCount;
-            for (int i = 0; i < empty_spots; i++)
-            {
-                BaseItem? b = GetRandomMovieTrailer(true, user);
-                if (b == null)
+                TrailerSelector trailerSelector = new TrailerSelector(item, user, Plugin.Instance.Configuration);
+                foreach (IntroInfo trailer in trailerSelector.GetTrailers())
                 {
-                    // No played movies
-                    break;
+                    yield return trailer;
                 }
-                yield return new IntroInfo { ItemId = b.Id, Path = b.Path };
             }
 
             // Return feature pre roll

--- a/Jellyfin.Plugin.CinemaMode/IntroManager.cs
+++ b/Jellyfin.Plugin.CinemaMode/IntroManager.cs
@@ -11,10 +11,10 @@ using Jellyfin.Data.Enums;
 
 namespace Jellyfin.Plugin.CinemaMode
 {
-    
+
     class TrailerSelector
     {
-        private List<Movie> Trailers { get; set; } = new List<Movie>(){ };
+        private List<Movie> Trailers { get; set; } = new List<Movie>() { };
         private int Returned { get; set; } = 0;
         private Random RNG { get; }
         private Jellyfin.Plugin.CinemaMode.Configuration.PluginConfiguration Config { get; }
@@ -33,7 +33,7 @@ namespace Jellyfin.Plugin.CinemaMode
                 q.HasOfficialRating = true;
                 q.MaxParentalRating = this.Feature.InheritedParentalRatingValue;
             }
-            
+
             List<Movie> movies = Plugin.LibraryManager.GetItemList(q).OfType<Movie>().Where(x => x.LocalTrailers.Count > 0).ToList();
 
             if (movies is not null)
@@ -60,7 +60,7 @@ namespace Jellyfin.Plugin.CinemaMode
             BaseItem item = movie.LocalTrailers.ElementAt(trailerID);
             return new IntroInfo { ItemId = item.Id, Path = item.Path };
         }
-        
+
         public IEnumerable<IntroInfo> GetTrailers()
         {
             // Unplayed
@@ -68,7 +68,7 @@ namespace Jellyfin.Plugin.CinemaMode
             while (this.Trailers.Count != 0 && this.Returned < this.Config.NumberOfTrailers)
             {
                 yield return this.PickAndPop();
-                this.Returned++;                 
+                this.Returned++;
             }
 
             // Break if we have reached count
@@ -84,7 +84,7 @@ namespace Jellyfin.Plugin.CinemaMode
                 yield return this.PickAndPop();
                 this.Returned++;
             }
-            
+
         }
     }
 
@@ -138,13 +138,13 @@ namespace Jellyfin.Plugin.CinemaMode
                 // likely a file permission error, default to none
                 return null;
             }
-            
+
         }
 
         public IEnumerable<IntroInfo> Get(BaseItem item, User user)
         {
             // Return trailer pre roll
-            if (Plugin.Instance.Configuration.EnableTrailerPreroll) 
+            if (Plugin.Instance.Configuration.EnableTrailerPreroll)
             {
                 BaseItem? b = GetRandomPreRoll(Plugin.Instance.Configuration.TrailerPreRollsPath, Plugin.Instance.Configuration.TrailerPreRollsChannelName);
                 if (b != null)
@@ -164,7 +164,7 @@ namespace Jellyfin.Plugin.CinemaMode
             }
 
             // Return feature pre roll
-            if (Plugin.Instance.Configuration.EnableFeaturePreroll) 
+            if (Plugin.Instance.Configuration.EnableFeaturePreroll)
             {
                 BaseItem? b = GetRandomPreRoll(Plugin.Instance.Configuration.FeaturePreRollsPath, Plugin.Instance.Configuration.FeaturePreRollsChannelName);
                 if (b != null)

--- a/Jellyfin.Plugin.CinemaMode/IntroProvider.cs
+++ b/Jellyfin.Plugin.CinemaMode/IntroProvider.cs
@@ -13,8 +13,8 @@ namespace Jellyfin.Plugin.CinemaMode
 
         public Task<IEnumerable<IntroInfo>> GetIntros(BaseItem item, User user)
         {
-           // Check item type, for now just pre roll movies
-            if (item is not MediaBrowser.Controller.Entities.Movies.Movie) 
+            // Check item type, for now just pre roll movies
+            if (item is not MediaBrowser.Controller.Entities.Movies.Movie)
             {
                 return Task.FromResult(Enumerable.Empty<IntroInfo>());
             }

--- a/Jellyfin.Plugin.CinemaMode/Jellyfin.Plugin.CinemaMode.csproj
+++ b/Jellyfin.Plugin.CinemaMode/Jellyfin.Plugin.CinemaMode.csproj
@@ -3,8 +3,8 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>Jellyfin.Plugin.CinemaMode</RootNamespace>
-    <AssemblyVersion>0.1.1.0</AssemblyVersion>
-    <FileVersion>0.1.1.0</FileVersion>
+    <AssemblyVersion>0.2.0.0</AssemblyVersion>
+    <FileVersion>0.2.0.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Jellyfin.Plugin.CinemaMode/Plugin.cs
+++ b/Jellyfin.Plugin.CinemaMode/Plugin.cs
@@ -8,6 +8,7 @@ using MediaBrowser.Model.Plugins;
 using MediaBrowser.Model.Serialization;
 using MediaBrowser.Controller;
 using MediaBrowser.Controller.Channels;
+using Microsoft.Extensions.Logging;
 
 namespace Jellyfin.Plugin.CinemaMode
 {
@@ -25,14 +26,16 @@ namespace Jellyfin.Plugin.CinemaMode
 
         public static ILibraryManager LibraryManager { get; private set; }
         public static IChannelManager ChannelManager { get; private set; }
+        public static ILogger<Plugin> Logger { get; private set; }
 
-        public Plugin(IApplicationPaths applicationPaths, IXmlSerializer xmlSerializer, ILibraryManager libraryManager, IServerApplicationPaths serverApplicationPaths, IChannelManager channelManager)
+        public Plugin(IApplicationPaths applicationPaths, IXmlSerializer xmlSerializer, ILibraryManager libraryManager, IServerApplicationPaths serverApplicationPaths, IChannelManager channelManager, ILogger<Plugin> logger)
             : base(applicationPaths, xmlSerializer)
         {
             Instance = this;
             LibraryManager = libraryManager;
             ServerApplicationPaths = serverApplicationPaths;
             ChannelManager = channelManager;
+            Logger = logger;
         }
 
         public IEnumerable<PluginPageInfo> GetPages()

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The plugin is designed to work with **local** content and provide a minimalist a
 
 ### Pre-Rolls
 
-Jellyfin does not manage this type of content out of the box so the plugin creates a ‘Pre-Roll’ channel to organize them. A channel was chosen primarily for its ability to be hidden from non-admin users. The channel has two sub folders, 'Trailer Pre-Rolls' and 'Feature Pre-Rolls'. Media locations for these folders are controlled in the plugins configuration page.
+Jellyfin does not manage this type of content out of the box so the plugin creates a 'Pre-Roll' channel to organize them. A channel was chosen primarily for its ability to be hidden from non-admin users. The channel has two sub folders, 'Trailer Pre-Rolls' and 'Feature Pre-Rolls'. 'Trailer Pre-Rolls' are videos meant to play prior to a block of trailers (think "Now playing on Jellyfin..."). 'Feature Pre-Rolls' are videos meant to play prior to the feature presentation (think "Now your feature presentation..."). Media locations for these folders are controlled in the plugins configuration page.
 
 Some important points about Pre-Rolls:
 1. All content in the channel is given the same rating so don't add content not suitable for all users.
@@ -40,7 +40,17 @@ Some important points about Pre-Rolls:
 
 The plugin will automatically find any trailers you have in your Jellyfin library. Just configure the number of trailers you want to play in the plugins configuration page and you’re good to go. 
 
-The plugin does not support playback of remote trailers. For information on how to add local trailers to Jellyfin, follow [this guide](https://jellyfin.org/docs/general/server/media/movies/#movie-extras). Getting trailers is another story. Scraping your Jellyfin library DB for youtube URLs to download is possible with a little bit of python. If there is sufficient demand I can create a github gist with more details on how to do this.
+By default, "Enforce Rating Limit" is enabled. This ensures the rating of the trailer content does not exceed that of the feature (i.e. trailers for an "R" rated movie will not be shown before a "PG-13" movie). This setting will cause any unrated content to have no trailers played prior and not be shown as a trailer. In this case "unrated" refers to content where the "Parental Rating" field is blank. It does not refer to content with an "NR" or "Not Rated" rating. Jellyfin considers content with a rating of "NR" as exceeding an "R" rating.
+
+ The plugin does not support playback of remote trailers. For information on how to add local trailers to Jellyfin, follow [this guide](https://jellyfin.org/docs/general/server/media/movies/#movie-extras). 
+
+### Troubleshooting
+
+If the plugin is not providing intros check the following:
+- "Cinema Mode" is enabeled in your users playback settings.
+- You have some trailers stored alongside your media following the naming conventions given [here](https://jellyfin.org/docs/general/server/media/movies/#movie-extras).
+- You can playback videos in the 'Trailer Pre-Rolls' and 'Feature Pre-Rolls' sub folders of the ‘Pre-Roll’ channel. Opening these folder will trigger a refresh that may fix your issue.
+- The Jellyfin service has at least read access to the directories containing your pre-rolls.
 
 ## Build Process
 

--- a/build.yaml
+++ b/build.yaml
@@ -1,6 +1,6 @@
 name: 'Cinema Mode'
 guid: '5fcefe1b-df1f-4596-ac57-f2f939c294c5'
-version: '0.1.1.0'
+version: '0.2.0.0'
 targetAbi: '10.8.0.0'
 framework: 'net6.0'
 owner: 'CherryFloors'

--- a/manifest.json
+++ b/manifest.json
@@ -9,6 +9,14 @@
         "imageUrl": "https://github.com/CherryFloors/jellyfin-plugin-cinemamode/raw/main/Jellyfin.Plugin.CinemaMode/Images/jellyfin-plugin-cinemamode.jpg",
         "versions": [
             {
+                "checksum": "3459c28435f14a61661754c4ad37d049",
+                "changelog": "Initial Release\n",
+                "targetAbi": "10.8.0.0",
+                "sourceUrl": "https://github.com/CherryFloors/jellyfin-plugin-cinemamode/releases/download/v0.2.0.0/cinemamode_0.2.0.0.zip",
+                "timestamp": "2023-07-30T11:08:21.449187",
+                "version": "0.2.0.0"
+            },
+            {
                 "checksum": "2008597b8f0d5fa03a9bfec09309bda1",
                 "changelog": "Fix trailer count\n",
                 "targetAbi": "10.8.0.0",


### PR DESCRIPTION
Adds documentation and rating limit setting

Fixes issue when a Jellyfin DB query returns movies that have a LocalTrailers list of length 0.