### PR TITLE
Dotnet 8 upgrade and jellyfin 10.9.2 patch

### DIFF
--- a/Jellyfin.Plugin.CinemaMode/Channels/PreRollsChannel.cs
+++ b/Jellyfin.Plugin.CinemaMode/Channels/PreRollsChannel.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Threading;
 using System.Threading.Tasks;
-using MediaBrowser.Common.Progress;
 using MediaBrowser.Controller.Channels;
 using MediaBrowser.Controller.Providers;
 using MediaBrowser.Controller.Entities;
@@ -91,7 +90,6 @@ public class PreRollsChannel : IChannel, IDisableMediaSourceDisplay, ISupportsMe
     /// <returns><see cref="ChannelItemResult"/> containing the types of trailers.</returns>
     private ChannelItemResult GetChannelTypes()
     {
-        _logger.LogDebug("Get Channel Types");
         return new ChannelItemResult
         {
             Items = new List<ChannelItemInfo>
@@ -246,7 +244,7 @@ public class PreRollsChannel : IChannel, IDisableMediaSourceDisplay, ISupportsMe
                     ChannelIds = new Guid[] { thisChannel.Id }
                 };
 
-                var result = await Plugin.ChannelManager.GetChannelItemsInternal(query, new SimpleProgress<double>(), cancellationToken).ConfigureAwait(false);
+                var result = await Plugin.ChannelManager.GetChannelItemsInternal(query, new Progress<double>(), cancellationToken).ConfigureAwait(false);
 
                 foreach (var item in result.Items)
                 {
@@ -260,7 +258,7 @@ public class PreRollsChannel : IChannel, IDisableMediaSourceDisplay, ISupportsMe
                                 EnableTotalRecordCount = false,
                                 ChannelIds = new Guid[] { thisChannel.Id }
                             },
-                            new SimpleProgress<double>(),
+                            new Progress<double>(),
                             cancellationToken).ConfigureAwait(false);
                     }
                 }

--- a/Jellyfin.Plugin.CinemaMode/Configuration/config.html
+++ b/Jellyfin.Plugin.CinemaMode/Configuration/config.html
@@ -14,6 +14,13 @@
                     </div>
                     <div class="verticalSection">
                         <p>
+                            <b>
+                                Note: Updates to Jellyfin have broken the current pre-roll implementation. The configuration
+                                sections will remain while a fix is implemented. They will not have any effect on plugin 
+                                behavior. The trailer playing functionality should still work as it did before.
+                            </b>
+                        </p>
+                        <p>
                             This plugin allows users to enable Jellyfin's Cinema Mode functionality with Trailer Pre-Rolls, 
                             Trailers, and Feature Pre-Rolls. Each of these can be configured/turned off in the sections 
                             below. All of this can be disabled at the user level by turning off Cinema Mode in the users 

--- a/Jellyfin.Plugin.CinemaMode/IntroProvider.cs
+++ b/Jellyfin.Plugin.CinemaMode/IntroProvider.cs
@@ -4,12 +4,20 @@ using System.Threading.Tasks;
 using Jellyfin.Data.Entities;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Library;
+using Microsoft.Extensions.Logging;
 
 namespace Jellyfin.Plugin.CinemaMode
 {
     public class IntroProvider : IIntroProvider
     {
         public string Name { get; } = "CinemaMode";
+
+        public readonly ILogger<IntroProvider> Logger;
+
+        public IntroProvider(ILogger<IntroProvider> logger)
+        {
+            this.Logger = logger;
+        }
 
         public Task<IEnumerable<IntroInfo>> GetIntros(BaseItem item, User user)
         {
@@ -19,7 +27,7 @@ namespace Jellyfin.Plugin.CinemaMode
                 return Task.FromResult(Enumerable.Empty<IntroInfo>());
             }
 
-            IntroManager introManager = new IntroManager();
+            IntroManager introManager = new IntroManager(this.Logger);
             return Task.FromResult(introManager.Get(item, user));
         }
 

--- a/Jellyfin.Plugin.CinemaMode/Jellyfin.Plugin.CinemaMode.csproj
+++ b/Jellyfin.Plugin.CinemaMode/Jellyfin.Plugin.CinemaMode.csproj
@@ -1,10 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>Jellyfin.Plugin.CinemaMode</RootNamespace>
-    <AssemblyVersion>0.2.0.0</AssemblyVersion>
-    <FileVersion>0.2.0.0</FileVersion>
+    <AssemblyVersion>0.3.0.0</AssemblyVersion>
+    <FileVersion>0.3.0.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Jellyfin.Plugin.CinemaMode/Plugin.cs
+++ b/Jellyfin.Plugin.CinemaMode/Plugin.cs
@@ -8,7 +8,6 @@ using MediaBrowser.Model.Plugins;
 using MediaBrowser.Model.Serialization;
 using MediaBrowser.Controller;
 using MediaBrowser.Controller.Channels;
-using Microsoft.Extensions.Logging;
 
 namespace Jellyfin.Plugin.CinemaMode
 {
@@ -26,16 +25,14 @@ namespace Jellyfin.Plugin.CinemaMode
 
         public static ILibraryManager LibraryManager { get; private set; }
         public static IChannelManager ChannelManager { get; private set; }
-        public static ILogger<Plugin> Logger { get; private set; }
 
-        public Plugin(IApplicationPaths applicationPaths, IXmlSerializer xmlSerializer, ILibraryManager libraryManager, IServerApplicationPaths serverApplicationPaths, IChannelManager channelManager, ILogger<Plugin> logger)
+        public Plugin(IApplicationPaths applicationPaths, IXmlSerializer xmlSerializer, ILibraryManager libraryManager, IServerApplicationPaths serverApplicationPaths, IChannelManager channelManager)
             : base(applicationPaths, xmlSerializer)
         {
             Instance = this;
             LibraryManager = libraryManager;
             ServerApplicationPaths = serverApplicationPaths;
             ChannelManager = channelManager;
-            Logger = logger;
         }
 
         public IEnumerable<PluginPageInfo> GetPages()

--- a/README.md
+++ b/README.md
@@ -27,14 +27,14 @@ More information about installing plugins can be found in the official docs [her
 
 The plugin is designed to work with **local** content and provide a minimalist approach to configuration at the moment. Open the plugin's configuration page by clicking on the thumbnail under 'My Plugins'.
 
-### Pre-Rolls
+### ~~Pre-Rolls~~
 
-Jellyfin does not manage this type of content out of the box so the plugin creates a 'Pre-Roll' channel to organize them. A channel was chosen primarily for its ability to be hidden from non-admin users. The channel has two sub folders, 'Trailer Pre-Rolls' and 'Feature Pre-Rolls'. 'Trailer Pre-Rolls' are videos meant to play prior to a block of trailers (think "Now playing on Jellyfin..."). 'Feature Pre-Rolls' are videos meant to play prior to the feature presentation (think "Now your feature presentation..."). Media locations for these folders are controlled in the plugins configuration page.
+~~Jellyfin does not manage this type of content out of the box so the plugin creates a 'Pre-Roll' channel to organize them. A channel was chosen primarily for its ability to be hidden from non-admin users. The channel has two sub folders, 'Trailer Pre-Rolls' and 'Feature Pre-Rolls'. 'Trailer Pre-Rolls' are videos meant to play prior to a block of trailers (think "Now playing on Jellyfin..."). 'Feature Pre-Rolls' are videos meant to play prior to the feature presentation (think "Now your feature presentation..."). Media locations for these folders are controlled in the plugins configuration page.~~
 
-Some important points about Pre-Rolls:
-1. All content in the channel is given the same rating so don't add content not suitable for all users.
-2. A scheduled task refreshes the Pre-Roll channel once per day. If you add/remove items or change the channel paths and want the changes reflected immediately, open each channel folder. This will trigger a refresh of channel contents, otherwise it will update within 24 hours.
-3. The folder containing your pre-rolls should contain only valid video files. The plugin will ignore any subdirectories and videos in them.
+~~Some important points about Pre-Rolls:~~
+1. ~~All content in the channel is given the same rating so don't add content not suitable for all users.~~
+2. ~~A scheduled task refreshes the Pre-Roll channel once per day. If you add/remove items or change the channel paths and want the changes reflected immediately, open each channel folder. This will trigger a refresh of channel contents, otherwise it will update within 24 hours.~~
+3. ~~The folder containing your pre-rolls should contain only valid video files. The plugin will ignore any subdirectories and videos in them.~~
 
 ### Trailers
 

--- a/build.yaml
+++ b/build.yaml
@@ -1,8 +1,8 @@
 name: 'Cinema Mode'
 guid: '5fcefe1b-df1f-4596-ac57-f2f939c294c5'
-version: '0.2.0.0'
-targetAbi: '10.8.0.0'
-framework: 'net6.0'
+version: '0.3.0.0'
+targetAbi: '10.9.0.0'
+framework: 'net8.0'
 owner: 'CherryFloors'
 overview: 'Enable Cinema Mode with local trailers and pre-rolls.'
 description: >

--- a/buildRelease.py
+++ b/buildRelease.py
@@ -6,9 +6,9 @@ import datetime
 import sys
 
 
-RELEASE_DIR = "Jellyfin.Plugin.CinemaMode/bin/release/net6.0/"
-RELEASE_DLL = "Jellyfin.Plugin.CinemaMode/bin/release/net6.0/Jellyfin.Plugin.CinemaMode.dll"
-RELEASE_META = "Jellyfin.Plugin.CinemaMode/bin/release/net6.0/meta.json"
+RELEASE_DIR = "Jellyfin.Plugin.CinemaMode/bin/release/net8.0/"
+RELEASE_DLL = "Jellyfin.Plugin.CinemaMode/bin/release/net8.0/Jellyfin.Plugin.CinemaMode.dll"
+RELEASE_META = "Jellyfin.Plugin.CinemaMode/bin/release/net8.0/meta.json"
 
 
 class Meta:

--- a/manifest.json
+++ b/manifest.json
@@ -9,6 +9,14 @@
         "imageUrl": "https://github.com/CherryFloors/jellyfin-plugin-cinemamode/raw/main/Jellyfin.Plugin.CinemaMode/Images/jellyfin-plugin-cinemamode.jpg",
         "versions": [
             {
+                "checksum": "c4192aa5f6d8434d318d5a80be35a72b",
+                "changelog": "Initial Release\n",
+                "targetAbi": "10.9.0.0",
+                "sourceUrl": "https://github.com/CherryFloors/jellyfin-plugin-cinemamode/releases/download/v0.3.0.0/cinemamode_0.3.0.0.zip",
+                "timestamp": "2024-05-19T14:59:05.278450",
+                "version": "0.3.0.0"
+            },
+            {
                 "checksum": "3459c28435f14a61661754c4ad37d049",
                 "changelog": "Initial Release\n",
                 "targetAbi": "10.8.0.0",


### PR DESCRIPTION
The purpose of this pr is to upgrade to dotnet 8 and patch the plugin so it is compatible with jellyfin 10.9.2. Pre roll functionality remains broken until a more stable implementation is completed.