### PR TITLE
patch exclude season and rating limit

### DIFF
--- a/Jellyfin.Plugin.CinemaMode/Configuration/config.html
+++ b/Jellyfin.Plugin.CinemaMode/Configuration/config.html
@@ -121,9 +121,8 @@
                             <div class="fieldDescription checkboxFieldDescription">
                                 Ensures the rating of the trailer content does not exceed that of the feature (i.e. trailers for an "R" 
                                 rated movie will not be shown before a "PG-13" movie). This setting will cause any unrated content to 
-                                have no trailers played prior and not be shown as a trailer. In this case "unrated" refers to content 
-                                where the "Parental Rating" field is blank. It does not refer to content with an "NR" or "Not Rated" rating.
-                                Jellyfin considers content with a rating of "NR" as exceeding an "R" rating.
+                                have no trailers played prior and not be shown as a trailer. In this case unrated refers to any content
+                                where the "Parental Rating" meta data field is marked "Unrated" or left blank. 
                             </div>
                         </div>
                     </fieldset>

--- a/Jellyfin.Plugin.CinemaMode/Jellyfin.Plugin.CinemaMode.csproj
+++ b/Jellyfin.Plugin.CinemaMode/Jellyfin.Plugin.CinemaMode.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Jellyfin.Controller" Version="10.9.0" />
-    <PackageReference Include="Jellyfin.Model" Version="10.9.0" />
+    <PackageReference Include="Jellyfin.Controller" Version="10.10.0" />
+    <PackageReference Include="Jellyfin.Model" Version="10.10.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ from being played any other time of the year.
 Pre-Roll's use the 'Movies' content type allowing them to be assigned ratings. This setting can be used if you have 
 Pre-Roll's that may not be suitable for all audiences and will ensure the rating of the Pre-Roll does not exceed that of
 the feature. Rating limits for Pre-Rolls are slightly different from trailers as Pre-Roll's that are not assigned
-ratings are considered suitable for all audiences. Enabled by default.
+ratings (`Unrated` or left `blank`) are considered suitable for all audiences. Enabled by default.
 
 ### Trailers
 
@@ -130,11 +130,10 @@ reached. Disabled by default.
 
 #### Enforce Rating Limit
 
-This ensures the rating of the trailer content does not exceed that of the feature (i.e. trailers for an "R" rated movie
-will not be shown before a "PG-13" movie). This setting will cause any unrated content to have no trailers played prior
-and not be shown as a trailer. In this case "unrated" refers to content where the "Parental Rating" field is blank. It
-does not refer to content with an "NR" or "Not Rated" rating. Jellyfin considers content with a rating of "NR" as
-exceeding an "R" rating. Enabled by default. 
+This ensures the rating of the trailer content does not exceed that of the feature (i.e. trailers for an `R` rated movie
+will not be shown before a `PG-13` movie). This setting will cause any unrated content to have no trailers played prior
+and not be shown as a trailer. In this case unrated refers to any content where the "Parental Rating" meta data field is
+marked `Unrated` or left blank. 
 
 ### Seasonal Tag Definitions
 

--- a/build.yaml
+++ b/build.yaml
@@ -1,7 +1,7 @@
 name: 'Cinema Mode'
 guid: '5fcefe1b-df1f-4596-ac57-f2f939c294c5'
-version: '0.4.0.0'
-targetAbi: '10.9.0.0'
+version: '0.5.0.0'
+targetAbi: '10.10.0.0'
 framework: 'net8.0'
 owner: 'CherryFloors'
 overview: 'Enable Cinema Mode with local trailers and pre-rolls.'
@@ -11,4 +11,6 @@ category: 'General'
 artifacts:
 - 'Jellyfin.Plugin.CinemaMode.dll'
 changelog: >
-  Stable Pre-Roll support and exapanded configuration
+  - New exclude out of season tags for pre-rolls logic that supports multiple out of season tags.
+  - Fix trailer rating enforcement to ignore "Unrated" and blank ratings.
+  - Target Jellyfin 10.10 ABI


### PR DESCRIPTION
Changes:
- New exclude out of season tags for pre-rolls logic that supports multiple out of season tags.
- Fix trailer rating enforcement to ignore "Unrated" and blank ratings.
- Clean build script
- Update version