### PR TITLE
Optionally only run intros from some of libraries

### DIFF
--- a/Jellyfin.Plugin.CinemaMode/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.CinemaMode/Configuration/PluginConfiguration.cs
@@ -74,6 +74,7 @@ namespace Jellyfin.Plugin.CinemaMode.Configuration
         public bool EnforceRatingLimitTrailers { get; set; }
         public int NumberOfTrailers { get; set; }
         public bool TrailerConsumeMode { get; set; }
+        public string IncludedLibraries { get; set; }
 
         public PluginConfiguration()
         {
@@ -90,6 +91,7 @@ namespace Jellyfin.Plugin.CinemaMode.Configuration
             NumberOfTrailers = 2;
             EnforceRatingLimitTrailers = true;
             TrailerConsumeMode = false;
+            IncludedLibraries = "";
         }
     }
 }

--- a/Jellyfin.Plugin.CinemaMode/Configuration/config.html
+++ b/Jellyfin.Plugin.CinemaMode/Configuration/config.html
@@ -203,11 +203,16 @@
                         <legend>
                             <h3 class="sectionTitle">Included Libraries</h3>
                         </legend>
-                        <div class="inputContainer">
-                            <label class="inputLabel inputLabelUnfocused" for="included-libraries">Library Names</label>
-                            <input type="text" id="included-libraries" name="included-libraries" is="emby-input"/>
+                        <div class="selectContainer selectLibrary flex-shrink-zero"> 
+                            <label class="selectLabel" for="includedLibrariesSelect">Target Libraries</label>
+                            <select is="emby-select" class="emby-select-withcolor emby-select" label="" id="includedLibrariesSelect" multiple>
+                            </select> 
+                            <div class="selectArrowContainer">
+                                <div style="visibility:hidden;display:none;">0</div>
+                                <span class="selectArrow material-icons keyboard_arrow_down" aria-hidden="true"></span>
+                            </div>
                             <div class="fieldDescription">
-                                Comma-separated list of library names where Cinema Mode should be active. Leave empty for all libraries.
+                                Select the movie libraries where Cinema Mode should be active. Hold Ctrl/Cmd to select multiple libraries. Leave empty for all libraries.
                             </div>
                         </div>
                     </fieldset>
@@ -483,6 +488,45 @@
                 });
             };
 
+            function initMultiselectLibrarySelector(selectorID, selectedLibraries) {
+                var selector = document.getElementById(selectorID);
+                mediaFolders.then((folderArray) => {
+                    // Clear existing options
+                    selector.innerHTML = "";
+                    
+                    // Add movie libraries
+                    for (const folder of folderArray) {
+                        if (folder.CollectionType == "movies") {
+                            var opt = document.createElement('option'); 
+                            opt.value = folder.Name; // Use library name as value
+                            opt.innerHTML = folder.Name;
+                            selector.appendChild(opt);
+                        };
+                    };
+                    
+                    // Set selected values
+                    if (selectedLibraries && selectedLibraries.trim() !== "") {
+                        var selectedArray = selectedLibraries.split(',').map(lib => lib.trim());
+                        for (let i = 0; i < selector.options.length; i++) {
+                            if (selectedArray.includes(selector.options[i].value)) {
+                                selector.options[i].selected = true;
+                            }
+                        }
+                    }
+                });
+            };
+
+            function getSelectedLibraries(selectorID) {
+                var selector = document.getElementById(selectorID);
+                var selected = [];
+                for (let i = 0; i < selector.options.length; i++) {
+                    if (selector.options[i].selected) {
+                        selected.push(selector.options[i].value);
+                    }
+                }
+                return selected.join(',');
+            }
+
             $('.cinemaModeConfigurationPage').on('pageshow', function () {
                 Dashboard.showLoadingMsg();
                 clearList('trailerPreRollLibrarySelect');
@@ -508,7 +552,7 @@
 
                     initSeasonalTagDefs(config.SeasonalTagDefinitions);
                     initTrailerRules(config.TrailerSelectionRules);
-                    $('#included-libraries').val(config.IncludedLibraries);
+                    initMultiselectLibrarySelector('includedLibrariesSelect', config.IncludedLibraries);
                     Dashboard.hideLoadingMsg();
                 });
             });
@@ -534,7 +578,7 @@
                     config.NumberOfTrailers = parseInt(NumberOfTrailers);
                     config.EnforceRatingLimitTrailers = document.getElementById('enforce-rating-limit-trailers').checked;
                     config.TrailerConsumeMode = document.getElementById('trailer-rules-consume-mode').checked;
-                    config.IncludedLibraries = $('#included-libraries').val();
+                    config.IncludedLibraries = getSelectedLibraries('includedLibrariesSelect');
 
                     ApiClient.updatePluginConfiguration(pluginId, config).then(Dashboard.processPluginConfigurationUpdateResult);
                 });

--- a/Jellyfin.Plugin.CinemaMode/Configuration/config.html
+++ b/Jellyfin.Plugin.CinemaMode/Configuration/config.html
@@ -197,6 +197,20 @@
                         <div class="paperList folderList" id="seasonal-tag-definitions">
                         </div>
                     </fieldset>
+
+                    <!-- Included Libraries -->
+                    <fieldset class="verticalSection verticalSection-extrabottompadding">
+                        <legend>
+                            <h3 class="sectionTitle">Included Libraries</h3>
+                        </legend>
+                        <div class="inputContainer">
+                            <label class="inputLabel inputLabelUnfocused" for="included-libraries">Library Names</label>
+                            <input type="text" id="included-libraries" name="included-libraries" is="emby-input"/>
+                            <div class="fieldDescription">
+                                Comma-separated list of library names where Cinema Mode should be active. Leave empty for all libraries.
+                            </div>
+                        </div>
+                    </fieldset>
                     <br/>
                     <button is="emby-button" type="submit" class="raised button-submit block"><span>${Save}</span></button>
                 </form>
@@ -494,6 +508,7 @@
 
                     initSeasonalTagDefs(config.SeasonalTagDefinitions);
                     initTrailerRules(config.TrailerSelectionRules);
+                    $('#included-libraries').val(config.IncludedLibraries);
                     Dashboard.hideLoadingMsg();
                 });
             });
@@ -519,6 +534,7 @@
                     config.NumberOfTrailers = parseInt(NumberOfTrailers);
                     config.EnforceRatingLimitTrailers = document.getElementById('enforce-rating-limit-trailers').checked;
                     config.TrailerConsumeMode = document.getElementById('trailer-rules-consume-mode').checked;
+                    config.IncludedLibraries = $('#included-libraries').val();
 
                     ApiClient.updatePluginConfiguration(pluginId, config).then(Dashboard.processPluginConfigurationUpdateResult);
                 });

--- a/Jellyfin.Plugin.CinemaMode/Configuration/config.html
+++ b/Jellyfin.Plugin.CinemaMode/Configuration/config.html
@@ -203,17 +203,22 @@
                         <legend>
                             <h3 class="sectionTitle">Included Libraries</h3>
                         </legend>
-                        <div class="selectContainer selectLibrary flex-shrink-zero"> 
-                            <label class="selectLabel" for="includedLibrariesSelect">Target Libraries</label>
-                            <select is="emby-select" class="emby-select-withcolor emby-select" label="" id="includedLibrariesSelect" multiple>
-                            </select> 
-                            <div class="selectArrowContainer">
-                                <div style="visibility:hidden;display:none;">0</div>
-                                <span class="selectArrow material-icons keyboard_arrow_down" aria-hidden="true"></span>
+                        <div class="checkboxContainer checkboxContainer-withDescription">
+                            <label>
+                                <input is="emby-checkbox" type="checkbox" id="include-all-libraries" name="include-all-libraries" />
+                                <span>Include All Libraries</span>
+                            </label>
+                            <div class="fieldDescription checkboxFieldDescription">
+                                When checked, Cinema Mode will be active for all movie libraries. When unchecked, only selected libraries below will be included.
                             </div>
-                            <div class="fieldDescription">
-                                Select the movie libraries where Cinema Mode should be active. Hold Ctrl/Cmd to select multiple libraries. Leave empty for all libraries.
-                            </div>
+                        </div>
+                        <div class="sectionTitleContainer flex align-items-center"> 
+                            <h4 class="sectionTitle">Specific Libraries</h4> 
+                        </div>
+                        <div class="paperList folderList" id="included-libraries-list">
+                        </div>
+                        <div class="fieldDescription">
+                            Select specific movie libraries where Cinema Mode should be active. If no libraries are selected and "Include All Libraries" is unchecked, Cinema Mode will be disabled.
                         </div>
                     </fieldset>
                     <br/>
@@ -527,6 +532,74 @@
                 return selected.join(',');
             }
 
+            function initLibraryCheckboxes(selectedLibraries) {
+                var container = document.getElementById('included-libraries-list');
+                container.innerHTML = "";
+                
+                mediaFolders.then((folderArray) => {
+                    var selectedArray = [];
+                    if (selectedLibraries && selectedLibraries.trim() !== "") {
+                        selectedArray = selectedLibraries.split(',').map(lib => lib.trim());
+                    }
+                    
+                    // Check if "all libraries" should be selected
+                    var includeAllLibraries = selectedArray.length === 0;
+                    document.getElementById('include-all-libraries').checked = includeAllLibraries;
+                    
+                    // Add movie libraries as checkboxes
+                    for (const folder of folderArray) {
+                        if (folder.CollectionType == "movies") {
+                            var listItem = document.createElement('div');
+                            listItem.setAttribute("class", "listItem listItem-border");
+                            
+                            var isSelected = selectedArray.includes(folder.Name);
+                            
+                            var innerHTML = '<div class="listItemBody">';
+                            innerHTML += '<label>';
+                            innerHTML += '<input type="checkbox" id="library-' + folder.Name.replace(/\s+/g, '-') + '" name="library-' + folder.Name.replace(/\s+/g, '-') + '"';
+                            if (isSelected) {
+                                innerHTML += ' checked';
+                            }
+                            innerHTML += ' />';
+                            innerHTML += '<span>' + folder.Name + '</span>';
+                            innerHTML += '</label>';
+                            innerHTML += '</div>';
+                            
+                            listItem.innerHTML = innerHTML;
+                            container.appendChild(listItem);
+                        }
+                    }
+                    
+                    // Add event listener for "Include All Libraries" checkbox
+                    document.getElementById('include-all-libraries').addEventListener('change', function() {
+                        var checkboxes = container.querySelectorAll('input[type="checkbox"]');
+                        for (let checkbox of checkboxes) {
+                            checkbox.checked = this.checked;
+                            checkbox.disabled = this.checked;
+                        }
+                    });
+                });
+            }
+
+            function getSelectedLibrariesFromCheckboxes() {
+                var includeAllLibraries = document.getElementById('include-all-libraries').checked;
+                if (includeAllLibraries) {
+                    return ""; // Empty string means all libraries
+                }
+                
+                var container = document.getElementById('included-libraries-list');
+                var checkboxes = container.querySelectorAll('input[type="checkbox"]:checked');
+                var selected = [];
+                
+                for (let checkbox of checkboxes) {
+                    // Extract library name from checkbox id (remove "library-" prefix and replace dashes with spaces)
+                    var libraryName = checkbox.id.replace('library-', '').replace(/-/g, ' ');
+                    selected.push(libraryName);
+                }
+                
+                return selected.join(',');
+            }
+
             $('.cinemaModeConfigurationPage').on('pageshow', function () {
                 Dashboard.showLoadingMsg();
                 clearList('trailerPreRollLibrarySelect');
@@ -552,7 +625,7 @@
 
                     initSeasonalTagDefs(config.SeasonalTagDefinitions);
                     initTrailerRules(config.TrailerSelectionRules);
-                    initMultiselectLibrarySelector('includedLibrariesSelect', config.IncludedLibraries);
+                    initLibraryCheckboxes(config.IncludedLibraries);
                     Dashboard.hideLoadingMsg();
                 });
             });
@@ -578,7 +651,7 @@
                     config.NumberOfTrailers = parseInt(NumberOfTrailers);
                     config.EnforceRatingLimitTrailers = document.getElementById('enforce-rating-limit-trailers').checked;
                     config.TrailerConsumeMode = document.getElementById('trailer-rules-consume-mode').checked;
-                    config.IncludedLibraries = getSelectedLibraries('includedLibrariesSelect');
+                    config.IncludedLibraries = getSelectedLibrariesFromCheckboxes();
 
                     ApiClient.updatePluginConfiguration(pluginId, config).then(Dashboard.processPluginConfigurationUpdateResult);
                 });

--- a/Jellyfin.Plugin.CinemaMode/IntroProvider.cs
+++ b/Jellyfin.Plugin.CinemaMode/IntroProvider.cs
@@ -14,25 +14,185 @@ namespace Jellyfin.Plugin.CinemaMode
 
         public readonly ILogger<IntroProvider> Logger;
 
+        // Add property to specify the target library name
+        public string TargetLibraryName { get; set; } = "Movies"; // Default to "Movies"
+
         public IntroProvider(ILogger<IntroProvider> logger)
         {
             this.Logger = logger;
+            this.Logger.LogInformation($"CinemaMode IntroProvider initialized with target library: '{TargetLibraryName}'");
         }
 
         public Task<IEnumerable<IntroInfo>> GetIntros(BaseItem item, User user)
         {
+            this.Logger.LogDebug($"GetIntros called for item: '{item.Name}' (ID: {item.Id}) by user: '{user.Username}'");
+
             // Check item type, for now just pre roll movies
             if (item is not MediaBrowser.Controller.Entities.Movies.Movie)
             {
+                this.Logger.LogDebug($"Skipping intros for item '{item.Name}' - not a movie (type: {item.GetType().Name})");
                 return Task.FromResult(Enumerable.Empty<IntroInfo>());
             }
 
+            this.Logger.LogDebug($"Item '{item.Name}' is a movie, proceeding with library check");
+
+            // Check if the item belongs to the target library
+            if (!string.IsNullOrEmpty(TargetLibraryName))
+            {
+                this.Logger.LogDebug($"Library filtering enabled. Target library: '{TargetLibraryName}'");
+                
+                var library = GetLibraryFromItem(item);
+                if (library == null)
+                {
+                    this.Logger.LogWarning($"Could not determine library for item '{item.Name}' (Path: {item.Path})");
+                    return Task.FromResult(Enumerable.Empty<IntroInfo>());
+                }
+
+                this.Logger.LogDebug($"Item '{item.Name}' found in library: '{library.Name}'");
+
+                if (!library.Name.Equals(TargetLibraryName, System.StringComparison.OrdinalIgnoreCase))
+                {
+                    this.Logger.LogInformation($"Skipping intros for item '{item.Name}' - in library '{library.Name}' but target is '{TargetLibraryName}'");
+                    return Task.FromResult(Enumerable.Empty<IntroInfo>());
+                }
+
+                this.Logger.LogInformation($"Item '{item.Name}' matches target library '{TargetLibraryName}', proceeding with intros");
+            }
+            else
+            {
+                this.Logger.LogDebug("Library filtering disabled (TargetLibraryName is null or empty), proceeding with intros for all movies");
+            }
+
+            this.Logger.LogDebug($"Creating IntroManager and getting intros for item '{item.Name}'");
             IntroManager introManager = new IntroManager(this.Logger);
-            return Task.FromResult(introManager.Get(item, user));
+            var intros = introManager.Get(item, user);
+            var introList = intros.ToList();
+            
+            this.Logger.LogInformation($"Found {introList.Count} intros for item '{item.Name}' in library '{TargetLibraryName}'");
+            foreach (var intro in introList)
+            {
+                this.Logger.LogDebug($"Intro: ItemId={intro.ItemId}, Path={intro.Path}");
+            }
+
+            return Task.FromResult(introList.AsEnumerable());
+        }
+
+        private MediaBrowser.Controller.Entities.CollectionFolder GetLibraryFromItem(BaseItem item)
+        {
+            this.Logger.LogDebug($"Getting library for item: '{item.Name}' (Path: {item.Path})");
+            
+            try
+            {
+                // Get all libraries and find the one that contains this item
+                var libraries = Plugin.LibraryManager.GetVirtualFolders();
+                this.Logger.LogDebug($"Found {libraries.Count()} total libraries");
+
+                foreach (var library in libraries)
+                {
+                    this.Logger.LogDebug($"Checking library: '{library.Name}' (ID: {library.ItemId}, Type: {library.CollectionType})");
+                    
+                    if (library.CollectionType.ToString().Equals("movies", System.StringComparison.OrdinalIgnoreCase))
+                    {
+                        this.Logger.LogDebug($"Library '{library.Name}' is a movie library, checking if item belongs to it");
+                        
+                        // Get the library folder
+                        var libraryFolder = Plugin.LibraryManager.GetItemById(library.ItemId) as MediaBrowser.Controller.Entities.CollectionFolder;
+                        if (libraryFolder == null)
+                        {
+                            this.Logger.LogWarning($"Could not get library folder for library '{library.Name}' (ID: {library.ItemId})");
+                            continue;
+                        }
+
+                        // Check if the item belongs to this library
+                        if (IsItemInLibrary(item, libraryFolder))
+                        {
+                            this.Logger.LogDebug($"Item '{item.Name}' belongs to library '{library.Name}'");
+                            return libraryFolder;
+                        }
+                        else
+                        {
+                            this.Logger.LogDebug($"Item '{item.Name}' does not belong to library '{library.Name}'");
+                        }
+                    }
+                    else
+                    {
+                        this.Logger.LogDebug($"Library '{library.Name}' is not a movie library (type: {library.CollectionType}), skipping");
+                    }
+                }
+
+                this.Logger.LogWarning($"Could not find a movie library containing item '{item.Name}'");
+            }
+            catch (System.Exception ex)
+            {
+                this.Logger.LogError($"Error getting library for item {item.Name}: {ex.Message}");
+                this.Logger.LogError($"Stack trace: {ex.StackTrace}");
+            }
+            return null;
+        }
+
+        private System.Guid GetLibraryIdFromItem(BaseItem item)
+        {
+            this.Logger.LogDebug($"GetLibraryIdFromItem called for item: '{item.Name}' (ID: {item.Id}, ParentId: {item.ParentId}, Path: {item.GetInternalMetadataPath()})");
+            
+            if (item.ParentId != System.Guid.Empty)
+            {
+                this.Logger.LogDebug($"Item '{item.Name}' has parent ID: {item.ParentId}, getting parent item");
+                
+                var parent = Plugin.LibraryManager.GetItemById(item.ParentId);
+                if (parent != null)
+                {
+                    this.Logger.LogDebug($"Found parent: '{parent.Name}' (ID: {parent.Id}, Type: {parent.GetType().Name})");
+                    
+                    if (parent is MediaBrowser.Controller.Entities.CollectionFolder)
+                    {
+                        this.Logger.LogDebug($"Parent '{parent.Name}' is a CollectionFolder (library), returning its ID: {parent.Id}");
+                        return parent.Id;
+                    }
+                    else
+                    {
+                        this.Logger.LogDebug($"Parent '{parent.Name}' is not a CollectionFolder, recursively checking its parent");
+                        return GetLibraryIdFromItem(parent);
+                    }
+                }
+                else
+                {
+                    this.Logger.LogWarning($"Could not find parent item with ID: {item.ParentId} for item '{item.Name}'");
+                }
+            }
+            else
+            {
+                this.Logger.LogDebug($"Item '{item.Name}' has no parent (ParentId is Guid.Empty)");
+            }
+            
+            this.Logger.LogDebug($"No library found for item '{item.Name}', returning Guid.Empty");
+            return System.Guid.Empty;
+        }
+
+        private bool IsItemInLibrary(BaseItem item, BaseItem libraryFolder)
+        {
+            this.Logger.LogDebug($"Checking if item '{item.Name}' (ID: {item.Id}) is in library folder '{libraryFolder.Name}' (ID: {libraryFolder.Id})");
+            
+            try
+            {
+                // Use InternalItemsQuery to check if the item is in the specific library
+                var query = new InternalItemsQuery();
+                query.AncestorIds = new System.Guid[] { libraryFolder.Id };
+                var libraryItems = Plugin.LibraryManager.GetItemList(query);
+                
+                bool isInLibrary = libraryItems.Any(libItem => libItem.Id == item.Id);
+                this.Logger.LogDebug($"Item '{item.Name}' found in library '{libraryFolder.Name}': {isInLibrary} (Library contains {libraryItems.Count} items)");
+                return isInLibrary;
+            }
+            catch (System.Exception ex)
+            {
+                this.Logger.LogError($"Error checking if item '{item.Name}' is in library '{libraryFolder.Name}': {ex.Message}");
+                return false;
+            }
         }
 
         public IEnumerable<string> GetAllIntroFiles()
         {
+            this.Logger.LogDebug("GetAllIntroFiles called - not implemented");
             // not implemented
             return Enumerable.Empty<string>();
         }

--- a/Jellyfin.Plugin.CinemaMode/Plugin.cs
+++ b/Jellyfin.Plugin.CinemaMode/Plugin.cs
@@ -24,12 +24,28 @@ namespace Jellyfin.Plugin.CinemaMode
 
         public static ILibraryManager LibraryManager { get; private set; }
 
+        /// <summary>
+        /// Reference to the IntroProvider instance for cache management.
+        /// </summary>
+        public static IntroProvider IntroProviderInstance { get; set; }
+
         public Plugin(IApplicationPaths applicationPaths, IXmlSerializer xmlSerializer, ILibraryManager libraryManager, IServerApplicationPaths serverApplicationPaths)
             : base(applicationPaths, xmlSerializer)
         {
             Instance = this;
             LibraryManager = libraryManager;
             ServerApplicationPaths = serverApplicationPaths;
+        }
+
+        /// <summary>
+        /// Clears the IntroProvider cache when configuration is updated.
+        /// </summary>
+        public static void ClearIntroProviderCache()
+        {
+            if (IntroProviderInstance != null)
+            {
+                IntroProviderInstance.ClearCache();
+            }
         }
 
         public IEnumerable<PluginPageInfo> GetPages()


### PR DESCRIPTION
This PR gives the option to only run intros for selected libraries, rather than all movie libraries.

As an example use case, I have a library for backgrounds that I put on for my dogs. I don't really want movie trailers running ever time I play one of those, but I do enjoy trailers before movies or stand-up comedy routines.