### PR TITLE
Add additional logging

### DIFF
--- a/Jellyfin.Plugin.CinemaMode/IntroManager.cs
+++ b/Jellyfin.Plugin.CinemaMode/IntroManager.cs
@@ -217,10 +217,14 @@ namespace Jellyfin.Plugin.CinemaMode
         public IntroInfo? GetPreRoll()
         {
             List<Movie> preRolls;
+            
+            Logger.LogDebug($"|jellyfin-cinema-mode| Fetching Pre-Rolls Type: {this.Category} User: {this.User} Library: {this.PreRollLibrary}");
+            
             foreach (PreRollSelectionConfig SelectConfig in this.PreRollsSelections)
             {
                 preRolls = QueryPreRolls(SelectConfig);
-                if (preRolls.Count > 0) {
+                if (preRolls.Count > 0)
+                {
                     int idx = this.RNG.Next(preRolls.Count);
                     Video preRoll = preRolls.ElementAt(idx);
                     return new IntroInfo { ItemId = preRoll.Id, Path = preRoll.Path };
@@ -423,9 +427,10 @@ namespace Jellyfin.Plugin.CinemaMode
 
         public IEnumerable<IntroInfo> Get(BaseItem item, User user)
         {
-
+            Logger.LogDebug("|jellyfin-cinema-mode| GET called for item: {ItemName} by user: {UserName}", item.Name, user.Username);
             if (Plugin.Instance.Configuration.TrailerPreRollsLibrary != "-")
             {
+                Logger.LogDebug("|jellyfin-cinema-mode| Fetching Trailer Pre-Roll from Library {Library}", Plugin.Instance.Configuration.TrailerPreRollsLibrary);
                 IntroInfo? trailerPreRoll = null;
                 try
                 {
@@ -440,17 +445,22 @@ namespace Jellyfin.Plugin.CinemaMode
 
                 if (trailerPreRoll != null)
                 {
+                    Logger.LogDebug("|jellyfin-cinema-mode| Trailer Pre-Roll ItemId: {ItemId}, Path: {Path}", trailerPreRoll.ItemId, trailerPreRoll.Path);
+
                     yield return trailerPreRoll;
                 }
             }
 
             if (Plugin.Instance.Configuration.NumberOfTrailers > 0)
             {
+                Logger.LogDebug("|jellyfin-cinema-mode| Fetching Trailers");
                 List<IntroInfo> trailers = new List<IntroInfo>();
                 try
                 {
                     TrailerSelector trailerSelector = new TrailerSelector(item, user, Plugin.Instance.Configuration, this.Logger);
                     trailers = trailerSelector.GetTrailers().ToList();
+
+                    Logger.LogDebug("|jellyfin-cinema-mode| Fetched {Count} Trailers for item: {ItemName} by user: {UserName}", trailers.Count, item.Name, user.Username);
                 }
                 catch (System.Exception e)
                 {
@@ -466,6 +476,8 @@ namespace Jellyfin.Plugin.CinemaMode
 
             if (Plugin.Instance.Configuration.FeaturePreRollsLibrary != "-")
             {
+                Logger.LogDebug("|jellyfin-cinema-mode| Fetching Feature Pre-Roll from Library {Library}", Plugin.Instance.Configuration.FeaturePreRollsLibrary);
+                
                 IntroInfo? featurePreRoll = null;
                 try
                 {

--- a/Jellyfin.Plugin.CinemaMode/IntroProvider.cs
+++ b/Jellyfin.Plugin.CinemaMode/IntroProvider.cs
@@ -21,18 +21,23 @@ namespace Jellyfin.Plugin.CinemaMode
 
         public Task<IEnumerable<IntroInfo>> GetIntros(BaseItem item, User user)
         {
+            Logger.LogDebug("|jellyfin-cinema-mode| GetIntros called for item: {ItemName} by user: {UserName}", item.Name, user.Username);
+
             // Check item type, for now just pre roll movies
             if (item is not MediaBrowser.Controller.Entities.Movies.Movie)
             {
+                Logger.LogDebug("|jellyfin-cinema-mode| Item is not a movie, returning empty intros.");
                 return Task.FromResult(Enumerable.Empty<IntroInfo>());
             }
 
+            Logger.LogDebug("|jellyfin-cinema-mode| Item is a movie, fetching intros.");
             IntroManager introManager = new IntroManager(this.Logger);
             return Task.FromResult(introManager.Get(item, user));
         }
 
         public IEnumerable<string> GetAllIntroFiles()
         {
+            Logger.LogDebug("|jellyfin-cinema-mode| GetAllIntroFiles called");
             // not implemented
             return Enumerable.Empty<string>();
         }


### PR DESCRIPTION
Enhance logging to provide better insights into the fetching process for pre-rolls and intros, aiding in debugging and monitoring.

I recently had issues with libraries, trailers not fetching..
Hence this extension of logging, that helped me better understand the process.