### PR TITLE
Add trailer download functionality with TMDb and YouTube integration

### DIFF
--- a/Jellyfin.Plugin.CinemaMode/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.CinemaMode/Configuration/PluginConfiguration.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using MediaBrowser.Model.Plugins;
 
@@ -75,6 +76,10 @@ namespace Jellyfin.Plugin.CinemaMode.Configuration
         public int NumberOfTrailers { get; set; }
         public bool TrailerConsumeMode { get; set; }
 
+        public string TmdbApiKey { get; set; }
+
+        public string[] TrailerDownloadLibraries { get; set; }
+
         public PluginConfiguration()
         {
             TrailerPreRollsLibrary = "-";
@@ -90,6 +95,10 @@ namespace Jellyfin.Plugin.CinemaMode.Configuration
             NumberOfTrailers = 2;
             EnforceRatingLimitTrailers = true;
             TrailerConsumeMode = false;
+
+            TrailerDownloadLibraries = [];
+
+            TmdbApiKey = string.Empty;
         }
     }
 }

--- a/Jellyfin.Plugin.CinemaMode/Configuration/config.html
+++ b/Jellyfin.Plugin.CinemaMode/Configuration/config.html
@@ -21,6 +21,11 @@
                             Playback settings. For more information, access the user guide via the above help button. 
                             Pro-tip: Skip any pre-roll or trailer by pressing the next button in the player.
                         </p>
+                        <p>
+                            NEW: It is also possible to automatically download trailers from TMDb / Youtube on a daily
+                            schedule as a task.
+                            The trailers will be stored locally, alongside the movies as "xyz-trailer.mp4".
+                        </p>
                         <div>
                             <img alt="Cinema Mode Diagram" width="800" height="auto" src="https://github.com/CherryFloors/jellyfin-plugin-cinemamode/raw/main/Jellyfin.Plugin.CinemaMode/Images/cinema-mode-diagram.png"/>
                             <div class="fieldDescription">
@@ -197,8 +202,49 @@
                         <div class="paperList folderList" id="seasonal-tag-definitions">
                         </div>
                     </fieldset>
-                    <br/>
-                    <button is="emby-button" type="submit" class="raised button-submit block"><span>${Save}</span></button>
+
+                    <!-- Auto Trailer Download  -->
+                    <fieldset class="verticalSection verticalSection-extrabottompadding">
+                        <legend>
+                            <h3 class="sectionTitle">Auto Trailer Download</h3>
+                        </legend>
+                        <div class="inputContainer">
+                            <div>
+                                <label class="inputLabel inputLabelUnfocused" for="tmdb-api-key">TMDb API Key:</label>
+                                <a is="emby-linkbutton" class="raised button-alt headerHelpButton emby-button" target="_blank" href="https://github.com/CherryFloors/jellyfin-plugin-cinemamode#auto-trailer-download">Help</a>
+                            </div>
+                            <input type="password" id="tmdb-api-key" name="tmdb-api-key" is="emby-input" />
+                            <div class="fieldDescription">
+                                The API Key, which must be obtained from <a
+                                    href="https://developer.themoviedb.org/docs/getting-started"
+                                    target="_blank">TMDb</a> for the downloads to work.
+                            </div>
+                        </div>
+                        <div class="checkboxContainer checkboxContainer-withDescription">
+                            <label>
+                                <input is="emby-checkbox" type="checkbox" id="trailer-download-include-all-libraries"
+                                    name="trailer-download-include-all-libraries" />
+                                <span>Include All Libraries</span>
+                                <a is="emby-linkbutton" class="raised button-alt headerHelpButton emby-button" target="_blank" href="https://github.com/CherryFloors/jellyfin-plugin-cinemamode#auto-trailer-download">Help</a>
+                            </label>
+                            <div class="fieldDescription checkboxFieldDescription">
+                                When checked, trailers will be downloaded for all movie libraries. When unchecked, only
+                                trailers for selected libraries below will be downloaded.
+                            </div>
+                        </div>
+                        <div class="sectionTitleContainer flex align-items-center">
+                            <h4 class="sectionTitle">Selected Libraries</h4>
+                        </div>
+                        <div class="paperList folderList" id="trailer-download-libraries-list">
+                        </div>
+                        <div class="fieldDescription">
+                            Select only specific movie libraries to download trailers from. If no libraries are
+                            selected and "Include All Libraries" is unchecked, no trailers will be downloaded at all.
+                        </div>
+                    </fieldset>
+                    <br />
+                    <button is="emby-button" type="submit"
+                        class="raised button-submit block"><span>${Save}</span></button>
                 </form>
             </div>
         </div>
@@ -469,6 +515,93 @@
                 });
             };
 
+            function initLibraryCheckboxes(selectedLibraries, selectAllID, libraryListID, prefix) {
+                var container = document.getElementById(libraryListID);
+                container.innerHTML = "";
+
+                // Check if "all libraries" should be selected
+                var selectedArray = selectedLibraries;
+                var includeAllLibraries = selectedArray.includes("*") && selectedArray.length === 1;
+
+                var selectAllCheckBox = document.getElementById(selectAllID);
+                selectAllCheckBox.checked = includeAllLibraries;
+
+                mediaFolders.then((folderArray) => {
+
+                    // Add movie libraries as checkboxes
+                    for (const folder of folderArray) {
+                        if (folder.CollectionType == "movies") {
+                            var listItem = document.createElement('div');
+                            listItem.setAttribute("class", "listItem listItem-border");
+
+                            var isSelected = selectedArray.includes(folder.ItemId);
+
+
+                            // Create label
+                            var label = document.createElement('label');
+
+                            // Create checkbox input
+                            var input = document.createElement('input');
+                            input.setAttribute('is', 'emby-checkbox');
+                            input.setAttribute('type', 'checkbox');
+                            input.setAttribute('id', prefix + folder.ItemId);
+                            input.setAttribute('name', prefix + folder.ItemId);
+                            input.setAttribute('data-itemId', folder.ItemId);
+                            if (isSelected) {
+                                input.setAttribute('checked', 'true');
+                            }
+
+                            // Create span for label text
+                            var span = document.createElement('span');
+                            span.textContent = folder.Name;
+
+                            // Assemble elements
+                            label.appendChild(input);
+                            label.appendChild(span);
+                            listItem.appendChild(label);
+
+                            container.appendChild(listItem);
+                        }
+                    }
+
+                    // Add event listener for "Include All Libraries" checkbox
+                    document.getElementById(selectAllID).addEventListener('change', function () {
+                        var checkboxes = container.querySelectorAll('input[type="checkbox"]');
+                        for (let checkbox of checkboxes) {
+                            checkbox.checked = this.checked;
+                            checkbox.disabled = this.checked;
+                        }
+                    });
+
+                    // Run same logic right away: if "includeAll" is ticked, all other checkboxes should be checked and disabled
+                    if (includeAllLibraries) {
+                        var checkboxes = container.querySelectorAll('input[type="checkbox"]');
+                        for (let checkbox of checkboxes) {
+                            checkbox.checked = true;
+                            checkbox.disabled = true;
+                        }
+                    }
+                });
+            }
+
+            function getSelectedLibrariesFromCheckboxes(selectAllID, libraryListID, prefix) {
+                var includeAllLibraries = document.getElementById(selectAllID).checked;
+                if (includeAllLibraries) {
+                    return ["*"];
+                }
+
+                var container = document.getElementById(libraryListID);
+                var checkboxes = container.querySelectorAll('input[type="checkbox"]:checked');
+                var selected = [];
+
+                for (let checkbox of checkboxes) {
+                    var id = checkbox.getAttribute("data-itemId");
+                    selected.push(id);
+                }
+
+                return selected;
+            }
+
             $('.cinemaModeConfigurationPage').on('pageshow', function () {
                 Dashboard.showLoadingMsg();
                 clearList('trailerPreRollLibrarySelect');
@@ -480,6 +613,7 @@
                 var page = this;
                 ApiClient.getPluginConfiguration(pluginId).then(function (config) {
                     $('#number-trailers', page).val(config.NumberOfTrailers);
+                    $('#tmdb-api-key', page).val(config.TmdbApiKey);
                     document.getElementById('enforce-rating-limit-trailers').checked = config.EnforceRatingLimitTrailers;
                     initLibrarySelector('trailerPreRollLibrarySelect', config.TrailerPreRollsLibrary, config.TrailerPreRollsLibrary);
                     initLibrarySelector('featurePreRollLibrarySelect', config.FeaturePreRollsLibrary, config.FeaturePreRollsLibrary);
@@ -494,6 +628,13 @@
 
                     initSeasonalTagDefs(config.SeasonalTagDefinitions);
                     initTrailerRules(config.TrailerSelectionRules);
+
+                    initLibraryCheckboxes(config.TrailerDownloadLibraries,
+                        'trailer-download-include-all-libraries',
+                        'trailer-download-libraries-list',
+                        'trailer-download-list-'
+                    );
+
                     Dashboard.hideLoadingMsg();
                 });
             });
@@ -504,6 +645,7 @@
                 var TrailerPreRollsLibrary = $('#trailerPreRollLibrarySelect').val();
                 var FeaturePreRollsLibrary = $('#featurePreRollLibrarySelect').val();
                 var NumberOfTrailers = $('#number-trailers').val();
+                var TmdbApiKey = $('#tmdb-api-key').val();
                 ApiClient.getPluginConfiguration(pluginId).then(function (config) {
 
                     config.TrailerPreRollsLibrary = TrailerPreRollsLibrary;
@@ -517,8 +659,10 @@
                     config.SeasonalTagDefinitions = getSeasonalTagDefs();
                     config.TrailerSelectionRules = getTrailerRules();
                     config.NumberOfTrailers = parseInt(NumberOfTrailers);
+                    config.TmdbApiKey = TmdbApiKey;
                     config.EnforceRatingLimitTrailers = document.getElementById('enforce-rating-limit-trailers').checked;
                     config.TrailerConsumeMode = document.getElementById('trailer-rules-consume-mode').checked;
+                    config.TrailerDownloadLibraries = getSelectedLibrariesFromCheckboxes('trailer-download-include-all-libraries', 'trailer-download-libraries-list', 'trailer-download-list-');
 
                     ApiClient.updatePluginConfiguration(pluginId, config).then(Dashboard.processPluginConfigurationUpdateResult);
                 });

--- a/Jellyfin.Plugin.CinemaMode/Jellyfin.Plugin.CinemaMode.csproj
+++ b/Jellyfin.Plugin.CinemaMode/Jellyfin.Plugin.CinemaMode.csproj
@@ -10,6 +10,8 @@
   <ItemGroup>
     <PackageReference Include="Jellyfin.Controller" Version="10.10.0" />
     <PackageReference Include="Jellyfin.Model" Version="10.10.0" />
+    <PackageReference Include="TMDbLib" Version="2.2.0" />
+    <PackageReference Include="YoutubeDlSharp" Version="1.1.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Jellyfin.Plugin.CinemaMode/TrailerDownloader/MediaItem.cs
+++ b/Jellyfin.Plugin.CinemaMode/TrailerDownloader/MediaItem.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Jellyfin.Data.Enums;
+using MediaBrowser.Controller.Entities.Movies;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Model.Entities;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.CinemaMode.TrailerDownloader;
+
+public class MediaItem
+{
+    public string Id { get; internal set; }
+    public string Title { get; internal set; }
+    public IEnumerable<string> Files { get; internal set; }
+    public string TmdbId { get; internal set; }
+}

--- a/Jellyfin.Plugin.CinemaMode/TrailerDownloader/TrailerDownloader.cs
+++ b/Jellyfin.Plugin.CinemaMode/TrailerDownloader/TrailerDownloader.cs
@@ -1,0 +1,287 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Data.Enums;
+using MediaBrowser.Controller.Entities.Movies;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Model.Entities;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using TMDbLib.Client;
+using TMDbLib.Objects.Search;
+
+namespace Jellyfin.Plugin.CinemaMode.TrailerDownloader;
+
+public class TrailerDownloader
+{
+    private readonly ILogger<TrailerDownloader> _logger;
+    private readonly IServiceProvider _serviceProvider;
+    private readonly TMDbClient _tmdbClient;
+    private readonly YoutubeDownloader _youtubeDownloader;
+    private readonly string[] _libraryIds;
+    private readonly string _downloadTempFolder;
+    private readonly ILibraryManager _libraryManager;
+    public TrailerDownloader(
+        string[] libraryIds,
+        string downloadTempFolder,
+        string tmdbApiKey,
+        ILibraryManager libraryManager,
+        ILogger<TrailerDownloader> logger,
+        IServiceProvider serviceProvider)
+    {
+        _logger = logger;
+        _serviceProvider = serviceProvider;
+
+        _tmdbClient = new TMDbClient(tmdbApiKey);
+
+        _youtubeDownloader = new YoutubeDownloader(_serviceProvider.GetService<ILogger<YoutubeDownloader>>());
+
+        if (libraryIds.Contains("*") && libraryIds.Length > 1)
+        {
+            throw new ArgumentOutOfRangeException(nameof(libraryIds), "LibraryIds must not be '*' and include ids at the same time.");
+        }
+        _libraryIds = libraryIds;
+
+        _downloadTempFolder = downloadTempFolder ?? throw new ArgumentNullException(nameof(downloadTempFolder));
+        _libraryManager = libraryManager;
+    }
+
+    public async Task<DownloadStats> RunAsync(
+        IProgress<double> progress = null,
+        CancellationToken cancellationToken = default)
+    {
+        var downloadStats = new DownloadStats();
+
+        _logger.LogDebug("Starting trailer download RunAsync...");
+
+        _logger.LogDebug("Temp folder is: {Folder}", _downloadTempFolder);
+
+        Directory.CreateDirectory(_downloadTempFolder);
+
+        // Cleaning up temp folder
+        _logger.LogDebug("Cleaning up temp folder");
+        foreach (var file in Directory.GetFiles(_downloadTempFolder, "*-trailer.mp4"))
+        {
+            _logger.LogDebug("Deleting file {file}", file);
+            File.Delete(file);
+        }
+
+        _logger.LogDebug("Initializing Youtube Downloader");
+        await _youtubeDownloader.Init();
+
+        List<MediaItem> jellyfinMovies = [];
+
+        if (_libraryIds.Length == 0)
+        {
+            _logger.LogWarning("No library selected in configuration. Skipping.");
+
+            // return empty stats and finish
+            return downloadStats;
+        }
+        else if (_libraryIds.Length == 1 && _libraryIds.Contains("*"))
+        {
+            _logger.LogInformation("Fetching movies with TMDb ID from all libraries");
+            // leaving guids as an empty array --> means ALL
+
+            jellyfinMovies.AddRange(await GetItemsWithTmdbIdAsync(null));
+        }
+        else
+        {
+            var guids = _libraryIds.Select(id => Guid.ParseExact(id, "N"));
+            _logger.LogInformation("Fetching movies with TMDb ID from selected libraries: {libs}", string.Join(',', guids));
+
+            foreach (var g in guids)
+            {
+                jellyfinMovies.AddRange(await GetItemsWithTmdbIdAsync(g));
+            }
+        }
+
+        _logger.LogInformation("Found {Count} movies with TMDb ID in library", jellyfinMovies.Count);
+
+        int movieIdx = 0;
+
+        downloadStats.Total = jellyfinMovies.Count;
+
+        foreach (var movie in jellyfinMovies)
+        {
+            movieIdx++;
+            progress?.Report(100.0 / jellyfinMovies.Count * movieIdx);
+
+            if (cancellationToken != default && cancellationToken.IsCancellationRequested)
+            {
+                _logger.LogInformation("Trailer download cancelled.");
+                return downloadStats;
+            }
+
+            _logger.LogInformation("Processing movie {Index}/{Count}: {Movie} [TMDbId: {Id}]",
+                movieIdx, jellyfinMovies.Count,
+                movie.Title,
+                movie.TmdbId);
+
+            if (movie.Files == null || !movie.Files.Any())
+            {
+                _logger.LogError("No files found for movie: {Movie}. Skipping.", movie.Title);
+                downloadStats.Error++;
+                continue;
+            }
+            if (!File.Exists(movie.Files.First()))
+            {
+                _logger.LogError("Movie file does not exist: {File}. Skipping.", movie.Files.First());
+                downloadStats.Error++;
+                continue;
+            }
+
+            string movieFolder = Path.TrimEndingDirectorySeparator(Path.GetDirectoryName(movie.Files.FirstOrDefault()));
+            if (string.IsNullOrEmpty(movieFolder) || !Directory.Exists(movieFolder))
+            {
+                _logger.LogError("No existing movie folder found for {Movie}. Skipping.", movie.Title);
+                downloadStats.Error++;
+                continue;
+            }
+
+            var movieFilename = Path.GetFileNameWithoutExtension(movie.Files.First());
+
+            _logger.LogDebug("File for movie: {Movie} [TMDbId: {Id}] - {file}",
+                movie.Title,
+                movie.TmdbId,
+                movie.Files.First());
+
+            string trailerFileName = $"{movieFilename}-trailer.mp4";
+
+            string trailerFullPath = "";
+            if (movieFolder.EndsWith(movieFilename))
+            {
+                // If the movie folder already ends with the movie filename, we assume it's already in a subfolder
+                trailerFullPath = Path.Combine(movieFolder, trailerFileName);
+            }
+            else
+            {
+                // Otherwise, we create a subfolder for the movie
+                trailerFullPath = Path.Combine(movieFolder, movieFilename, trailerFileName);
+            }
+
+            _logger.LogDebug("Trailer file name: {Trailerfile}", trailerFileName);
+            _logger.LogDebug("Trailer full path: {Trailerfile}", trailerFullPath);
+
+            if (File.Exists(trailerFullPath))
+            {
+                _logger.LogInformation("Trailer already exists, skipping.");
+                downloadStats.Existing++;
+                continue;
+            }
+
+            if (Directory.Exists(Path.GetDirectoryName(trailerFullPath)))
+            {
+                _logger.LogWarning("Subfolder already exists: {Folder}", Path.GetDirectoryName(trailerFullPath));
+                // downloadStats.Error++;
+                // continue;
+            }
+
+            var tmdbMovie = await _tmdbClient.GetMovieAsync(movie.TmdbId, TMDbLib.Objects.Movies.MovieMethods.Videos, cancellationToken);
+            if (tmdbMovie?.Videos?.Results == null)
+            {
+                _logger.LogWarning("No trailer found in TMDb for movie: {Movie}. Skipping.", movie.Title);
+                downloadStats.NoTrailer++;
+                continue;
+            }
+
+            var trailerKey = tmdbMovie.Videos.Results
+                .Where(v => v.Type == "Trailer" && v.Site == "YouTube")
+                .Select(v => v.Key)
+                .FirstOrDefault();
+
+            if (string.IsNullOrEmpty(trailerKey))
+            {
+                _logger.LogWarning("No trailer found in TMDb for movie: {Movie}. Skipping.", movie.Title);
+                downloadStats.NoTrailer++;
+                continue;
+            }
+
+            var trailerUrl = $"https://www.youtube.com/watch?v={trailerKey}";
+
+            _logger.LogInformation("Downloading trailer for {Movie}: {Url}", movie.Title, trailerUrl);
+
+            bool success = await _youtubeDownloader.DownloadAsync(
+                trailerUrl,
+                Path.GetFileNameWithoutExtension(trailerFileName),
+                _downloadTempFolder);
+
+            if (!success)
+            {
+                _logger.LogWarning("Download failed for {Movie}: {Url}. Skipping.", movie.Title, trailerUrl);
+                downloadStats.DownloadError++;
+                continue;
+            }
+
+            _logger.LogInformation("Trailer downloaded for {Movie}: {Url}", movie.Title, trailerUrl);
+
+            string finalFolder = Path.GetDirectoryName(trailerFullPath)!;
+            Directory.CreateDirectory(finalFolder);
+
+            _logger.LogDebug("Moving trailer to {Path}", trailerFullPath);
+
+            File.Move(Path.Combine(_downloadTempFolder, trailerFileName), trailerFullPath);
+            _logger.LogDebug("Trailer moved to: {Path}", trailerFullPath);
+
+            var movieFiles = Directory.GetFiles(movieFolder, $"{movieFilename}*.*");
+            foreach (var file in movieFiles)
+            {
+                var dest = Path.Combine(finalFolder, Path.GetFileName(file));
+
+                if (!File.Exists(dest) && file != dest)
+                {
+                    _logger.LogDebug("Moving movie file {File} to {dest}", file, dest);
+                    File.Move(file, dest);
+                }
+            }
+
+            _logger.LogInformation("Downloaded trailer for {Movie} to {Folder}", movie.Title, finalFolder);
+            downloadStats.Downloaded++;
+        }
+
+        return downloadStats;
+    }
+
+    private Task<IEnumerable<MediaItem>> GetItemsWithTmdbIdAsync(Guid? parentId)
+    {
+        var query = new MediaBrowser.Controller.Entities.InternalItemsQuery
+        {
+            EnableTotalRecordCount = true,
+            IsVirtualItem = false,
+            HasTmdbId = true,
+            Recursive = true,
+            IncludeItemTypes = [BaseItemKind.Movie],
+        };
+
+        // if there is a parentId passed, only fetch for specific parent
+        if (parentId.HasValue)
+        {
+            query.ParentId = parentId.Value;
+        }
+
+        var itemsWithTmdb = _libraryManager.GetItemList(query).OfType<Movie>()
+        .Where(item => item.HasProviderId(MetadataProvider.Tmdb))
+        .Select(item => new MediaItem
+        {
+            Id = item.Id.ToString(),
+            Title = item.Name,
+            Files = item.GetMediaSources(false).Select(file => file.Path).ToList(),
+            TmdbId = item.GetProviderId("Tmdb")
+        });
+
+        return Task.FromResult(itemsWithTmdb);
+    }
+
+    public class DownloadStats
+    {
+        public int Total { get; set; }
+        public int Downloaded { get; set; }
+        public int Error { get; set; }
+        public int Existing { get; set; }
+        public int NoTrailer { get; set; }
+        public int DownloadError { get; set; }
+    }
+}

--- a/Jellyfin.Plugin.CinemaMode/TrailerDownloader/YoutubeDownloader.cs
+++ b/Jellyfin.Plugin.CinemaMode/TrailerDownloader/YoutubeDownloader.cs
@@ -1,0 +1,68 @@
+namespace Jellyfin.Plugin.CinemaMode.TrailerDownloader;
+
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using System;
+using System.IO;
+using System.Linq;
+
+public class YoutubeDownloader
+{
+    private readonly ILogger<YoutubeDownloader> _logger;
+    public YoutubeDownloader(ILogger<YoutubeDownloader> logger)
+    {
+        _logger = logger;
+    }
+
+    public async Task Init()
+    {
+        _logger.LogDebug("Downloading binaries...");
+
+        await YoutubeDLSharp.Utils.DownloadBinaries();
+
+        _logger.LogDebug("Binaries downloaded successfully.");
+
+        if (OperatingSystem.IsLinux() || OperatingSystem.IsMacOS())
+        {
+            _logger.LogDebug("Setting executable permissions for yt-dlp on Linux...");
+
+            // Fix a bug in YoutubeDlSharp here
+            File.SetUnixFileMode("yt-dlp", UnixFileMode.UserExecute | UnixFileMode.UserRead | UnixFileMode.UserWrite |
+                                      UnixFileMode.GroupExecute | UnixFileMode.GroupRead |
+                                      UnixFileMode.OtherExecute | UnixFileMode.OtherRead);
+
+            _logger.LogDebug("Executable permissions set for yt-dlp on Linux.");
+        }
+    }
+
+    public async Task<bool> DownloadAsync(string url, string title, string outputFolder)
+    {
+        var youtubeDl = new YoutubeDLSharp.YoutubeDL
+        {
+            // YoutubeDLPath = "yt-dlp",
+            // FFmpegPath = "ffmpeg",
+            OutputFolder = outputFolder
+        };
+
+        _logger.LogDebug("Starting download for '{Title}' from {Url}", title, url);
+        var options = new YoutubeDLSharp.Options.OptionSet() { Output = $"{youtubeDl.OutputFolder}/{title}.%(ext)s" };
+
+        var result = await youtubeDl.RunVideoDownload(url, format: "mp4", overrideOptions: options);
+
+        if (!result.Success)
+        {
+            _logger.LogError("Youtube download failed for {Title}: {Error}", title, result.ErrorOutput);
+
+            if (result.ErrorOutput.Contains("/usr/bin/env: ‘python3’: No such file or directory"))
+            {
+                _logger.LogCritical("Python3 not found on the machine, cannot download trailers!");
+                throw new("Python3 not found on the machine, cannot download trailers!");
+            }
+
+            return false;
+        }
+
+        _logger.LogDebug("Download succeeded: {Title}", title);
+        return true;
+    }
+}

--- a/Jellyfin.Plugin.CinemaMode/TrailerDownloaderScheduledTask.cs
+++ b/Jellyfin.Plugin.CinemaMode/TrailerDownloaderScheduledTask.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Model.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.DependencyInjection;
+using MediaBrowser.Common;
+using MediaBrowser.Controller;
+using System.IO;
+
+namespace Jellyfin.Plugin.CinemaMode;
+
+public class TrailerDownloadScheduledTask : IScheduledTask
+{
+    private readonly ILibraryManager _libraryManager;
+    private readonly IServiceProvider _serviceProvider;
+    private readonly ILogger<TrailerDownloadScheduledTask> _logger;
+    private readonly string _tempPath;
+
+    public string Name => "Download Trailers";
+    public string Key => "TrailerDownloaderScheduledTask";
+    public string Description => "Downloads trailers for movies in the library and puts them on the local folder.";
+    public string Category => "Cinema Mode";
+
+    public TrailerDownloadScheduledTask(
+        ILibraryManager libraryManager,
+        IServiceProvider serviceProvider,
+        ILogger<TrailerDownloadScheduledTask> logger)
+    {
+        _libraryManager = libraryManager;
+        _serviceProvider = serviceProvider;
+        _logger = logger;
+
+        _tempPath = Path.Combine(Plugin.Instance.DataFolderPath, "downloads");
+
+        _logger.LogDebug("Using temp path: {TempPath}", _tempPath);
+    }
+
+    public async Task ExecuteAsync(IProgress<double> progress, CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Starting TrailerDownload Scheduled Task...");
+
+        if (string.IsNullOrEmpty(Plugin.Instance.Configuration.TmdbApiKey))
+        {
+            _logger.LogError("TMDB API Key is not configured. Please set the TMDB API Key in the plugin configuration. Trailer download will not proceed.");
+            return;
+        }
+
+        var trailerDownloader = new TrailerDownloader.TrailerDownloader(
+            libraryIds: Plugin.Instance.Configuration.TrailerDownloadLibraries,
+            downloadTempFolder: _tempPath,
+            tmdbApiKey: Plugin.Instance.Configuration.TmdbApiKey,
+            libraryManager: _libraryManager,
+            logger: _serviceProvider.GetService<ILogger<TrailerDownloader.TrailerDownloader>>(),
+            serviceProvider: _serviceProvider
+            );
+
+        var stats = await trailerDownloader.RunAsync(progress, cancellationToken);
+
+        _logger.LogInformation("TrailerDownload Scheduled Task completed successfully.");
+        _logger.LogInformation("   {s} movies with TMDb ID processed", stats.Total);
+        _logger.LogInformation("   {s} movies with existing trailers", stats.Existing);
+        _logger.LogInformation("   {s} trailers downloaded", stats.Downloaded);
+        _logger.LogInformation("   {s} movies with no trailer", stats.NoTrailer);
+        _logger.LogInformation("   {s} errors while downloading trailers", stats.DownloadError);
+        _logger.LogInformation("   {s} errors", stats.Error);
+    }
+
+    public IEnumerable<TaskTriggerInfo> GetDefaultTriggers()
+    {
+        return
+        [
+            new TaskTriggerInfo
+            {
+                Type = TaskTriggerInfo.TriggerDaily,
+                TimeOfDayTicks = TimeSpan.FromHours(7).Add(TimeSpan.FromMinutes(30)).Ticks, // Run daily at 7:30 AM
+            }
+        ];
+    }
+}

--- a/Jellyfin.Plugin.CinemaMode/TrailerDownloaderScheduledTask.cs
+++ b/Jellyfin.Plugin.CinemaMode/TrailerDownloaderScheduledTask.cs
@@ -74,7 +74,7 @@ public class TrailerDownloadScheduledTask : IScheduledTask
         [
             new TaskTriggerInfo
             {
-                Type = TaskTriggerInfo.TriggerDaily,
+                Type = TaskTriggerInfoType.DailyTrigger,
                 TimeOfDayTicks = TimeSpan.FromHours(7).Add(TimeSpan.FromMinutes(30)).Ticks, // Run daily at 7:30 AM
             }
         ];


### PR DESCRIPTION
A new scheduled task to download trailers from youtube to the local machine:
- Get library items with TMDb ID
- Lookup TMDb item in the online TMDb API and get trailer video links
- Download associated Youtube trailer video links into the local library

Whats new:
- Added scheduled task for automatic trailer downloads.
- Implemented trailer downloading logic in a new TrailerDownloader class.
- Added necessary dependencies for TMDb and YouTube downloading.
- Introduced new configuration options for TMDb API key and trailer download libraries.
- Updated HTML configuration to support new features.