### PR TITLE
Add Jellyfin 12.0 build target

### DIFF
--- a/Jellyfin.Plugin.CinemaMode/Jellyfin.Plugin.CinemaMode.csproj
+++ b/Jellyfin.Plugin.CinemaMode/Jellyfin.Plugin.CinemaMode.csproj
@@ -1,15 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <RootNamespace>Jellyfin.Plugin.CinemaMode</RootNamespace>
     <AssemblyVersion>0.6.0.0</AssemblyVersion>
     <FileVersion>0.6.0.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Jellyfin.Controller" Version="10.11.0" />
-    <PackageReference Include="Jellyfin.Model" Version="10.11.0" />
+    <PackageReference Include="Jellyfin.Controller" Version="12.0.0-rc5" />
+    <PackageReference Include="Jellyfin.Model" Version="12.0.0-rc5" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Adds a Jellyfin 12.0 build target.

Retargets to `net10.0` against the Jellyfin `12.0.0-rc5` NuGet packages. Where the project already
parameterises on `<JellyfinVersion>`, this just teaches that existing machinery about 12.x and
leaves the older targets untouched.

Built and loaded successfully on Jellyfin 12.0-rc5.
